### PR TITLE
Disable frustum culling in more complicated models

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,9 +59,8 @@ AFRAME.registerComponent('avatar', {
     const model = await new Promise((res, rej) => {
       new THREE.GLTFLoader().load(this.data.model, gltf => {
         gltf.frustumCulled = false;
-        const meshes = gltf.scene.children[0].children;
-        meshes.forEach(o => {
-          if (o.type === 'SkinnedMesh') {
+        gltf.scene.traverse(o => {
+          if (o.type === 'SkinnedMesh' || o.type === 'Mesh') {
             o.material.side = THREE.FrontSide;
             o.frustumCulled = false;
           }


### PR DESCRIPTION
This PR disables frustum culling completely in models that have (potentially unskinned) subobjects.